### PR TITLE
Added menu_item_parents = [] variable to sub_menu.php to stop array error

### DIFF
--- a/includes/sub_menu.php
+++ b/includes/sub_menu.php
@@ -95,6 +95,8 @@ function d7_wp_nav_menu_objects_sub_menu( $sorted_menu_items, $args ) {
 
 		} // Not direct_parent
 
+		$menu_item_parents = [];
+
 		// Loop through items and unset ones outside of the tree
 		foreach ( $sorted_menu_items as $key => $item ) {
 


### PR DESCRIPTION
I was getting the following error when using the new sub-menu code.

```
Warning: array_key_exists() expects parameter 2 to be array, null given in sub_menu.php on line 106

Warning: array_key_exists() expects parameter 2 to be array, null given in sub_menu.php on line 111﻿
```

so I added `$menu_item_parents = [];` and that stopped the error.
